### PR TITLE
expose carbonapi port

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Host | Container | Service
 2003 |      2003 | [carbon receiver - plaintext](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
 2004 |      2004 | [carbon receiver - pickle](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-pickle-protocol)
 
+### Optional Ports
+
+Host | Container | Service
+---- | --------- | -------------------------------------------------------------------------------------------------------------------
+8081 |      8081 | [carbonapi](https://github.com/go-graphite/carbonapi)
+
 ### Mounted Volumes
 
 Host              | Container                  | Notes

--- a/conf/etc/carbonapi/carbonapi.yaml
+++ b/conf/etc/carbonapi/carbonapi.yaml
@@ -1,5 +1,5 @@
 # Listen address, should always include hostname or ip address and a port.
-listen: "localhost:8081"
+listen: "0.0.0.0:8081"
 # Max concurrent requests to CarbonZipper
 concurency: 20
 cache:


### PR DESCRIPTION
we're using this container in our test/dev setups where we talk to carbonapi directly, but i think it's useful in general to be able to expose this service