### PR TITLE
Update carbonapi listen IP so it can be exposed outside of docker

### DIFF
--- a/conf/etc/carbonapi/carbonapi.yaml
+++ b/conf/etc/carbonapi/carbonapi.yaml
@@ -8,7 +8,7 @@
 # you should set it to URL of go-carbon's carbonserver module
 # or graphite-clickhouse's http url.
 # Listen address, should always include hostname or ip address and a port.
-listen: "localhost:8081"
+listen: "0.0.0.0:8081"
 # Specify URL Prefix for all handlers
 prefix: ""
 # Specify if metrics are exported over HTTP and if they are available on the same address or not


### PR DESCRIPTION
Fixes: https://github.com/go-graphite/docker-go-graphite/issues/11

I tested it with both internal (inside docker) and external (another docker instance) and I could connect with both