### PR TITLE
Include information about expose ports which are not mapped by quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Host | Container | Service
 2003 |      2003 | [carbon receiver - plaintext](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
 2004 |      2004 | [carbon receiver - pickle](http://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-pickle-protocol)
 
+### Exposed Ports
+
+Container | Service
+--------- | -------------------------------------------------------------------------------------------------------------------
+     8081 | [caronapi](https://github.com/go-graphite/carbonapi/blob/master/doc/configuration.md#general-configuration-for-carbonapi)
+
 ### Mounted Volumes
 
 Host              | Container                  | Notes


### PR DESCRIPTION
As I wrote here: https://github.com/go-graphite/docker-go-graphite/issues/11#issuecomment-674069443 the expose port for carbonapi is not written anywhere. 

I was not sure if I should add 8080, because it probably needs changes in the configuration (it uses `127.0.0.1` instead of `0.0.0.0`). 

I am also not sure if I should change the quick start to include carbonapi exposure since grafana is already configured.